### PR TITLE
[support] fix eslint dependencies

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -24,7 +24,7 @@
     "prettier": "^2.6.2",
     "typescript": ">=3.3.1"
   },
-  "devDependencies": {
+  "dependencies": {
     "@next/eslint-plugin-next": "^12.1.6",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.0.0",
@@ -39,9 +39,7 @@
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-react-perf": "^3.3.1",
-    "eslint-plugin-storybook": "^0.5.7",
-    "prettier": "^2.6.2",
-    "typescript": "4.6.3"
+    "eslint-plugin-storybook": "^0.5.7"
   },
   "repository": "https://github.com/evrone-erp/frontend-shared",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16776,11 +16776,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
-
 typescript@4.6.4:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"


### PR DESCRIPTION
change devDependencies to dependencies to prevent installing all eslint packages manually in each place where it is used